### PR TITLE
Add sponsors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ Generate business leads from Google Maps, create personalized marketing content 
 
 ---
 
+## 🤝 Sponsors
+
+<table>
+  <tr>
+    <td align="center">
+      <a href="https://www.coreclaw.com/?utm_source=github&utm_medium=referral&utm_campaign=asiifdev&utm_term=&utm_id=asiifdev">
+        <strong>🚀 CoreClaw</strong><br/>
+        Turn Google Maps Data Into Real Business Leads<br/>
+        Find websites, emails, and business contacts from Google Maps in minutes.<br/>
+        <strong>👉 Get 1,000 free leads →</strong>
+      </a>
+    </td>
+  </tr>
+</table>
+
+> Want to sponsor this project? See [GitHub Sponsors](https://github.com/sponsors/asiifdev) or reach out directly.
+
+---
+
 ## 🎯 What it does
 
 This tool helps you:


### PR DESCRIPTION
## Summary
Added a new "Sponsors" section to the README to highlight project sponsors and provide information about sponsorship opportunities.

## Changes
- Added a new sponsors section with a table layout featuring CoreClaw as the primary sponsor
- Included CoreClaw's value proposition with a call-to-action link to their service
- Added a note directing users to GitHub Sponsors or direct contact for sponsorship inquiries
- Positioned the sponsors section prominently after the introduction and before the "What it does" section

## Details
The sponsors section uses a clean table format to showcase sponsor information with:
- A direct link to CoreClaw's website with UTM parameters for tracking
- Clear messaging about the sponsor's service offering
- A prominent call-to-action button
- An invitation for additional sponsors to get involved with the project

https://claude.ai/code/session_01SmUaQiM7pu1oSet4aAf8cw